### PR TITLE
add docker-support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+
+COPY . /app
+WORKDIR /app
+RUN pip install -r requirements.txt
+RUN chmod +x entrypoint.sh
+ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.2"
+services:
+  api:
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - 8081:8000
+    environment:
+      DATABASE_HOST: database
+      DATABASE_USER: api_user
+      DATABASE_PASSWORD: api_password
+      DATABASE_NAME: api_database
+      DATABASE_PORT: 5432
+      APP_DEBUG: 1
+      APP_SECRET_KEY: a
+    links: 
+      - database
+  
+  database:
+    image: postgres:12
+    volumes:
+      - ./postgres-data:/var/lib/postgresql
+    environment:
+      POSTGRES_PASSWORD: api_password
+      POSTGRES_USER: api_user
+      POSTGRES_DB: api_database
+  
+  adminer:
+    image: adminer
+    ports:
+      - 8082:8080
+    links:
+      - database

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+python manage.py migrate
+python manage.py loaddata api/fixtures/*.json
+python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
Damit sollte man die API lokal ganz leicht betreiben können. Ist für die Entwicklung ganz praktisch.